### PR TITLE
Unauthed images

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,3 +1,5 @@
+export const cdnRoute = "https://av-cdn.bsky.app";
+
 export async function getPost(userId, postId) {
   
   try {

--- a/feed.js
+++ b/feed.js
@@ -74,7 +74,7 @@ async function userFeed() {
   }
 }
 
-function artificialFeed() {
+async function artificialFeed() {
   
   var feedStruct = "";
 
@@ -103,6 +103,25 @@ function artificialFeed() {
         if (record.$type === "app.bsky.feed.post") {
 
           record.uri = "at://" + body.repo + "/" + body.ops[0].path;
+
+          if (record.embed) {
+
+            if (record.embed.$type === "app.bsky.embed.images") {
+
+              var item = record.embed.images[0].image.ref.value.buffer;
+
+              for (var i = 0; i < record.embed.images.length; i++) {
+
+                console.log(record, record.embed.images[i].image.ref.value)
+                record.embed.images[i].image.ref.value = await decode(record.embed.images[i].image.ref.value)
+              }
+            }
+          }
+
+          //var imgcid = decode(record.embeds.images[0].image.ref.$link);
+
+          if (item) console.log(item)
+
           const postStruct = await postDefault(body.repo, record, "feed");
 
           feedStruct = postStruct + feedStruct;

--- a/labels.js
+++ b/labels.js
@@ -301,7 +301,7 @@ export function isExplicit(labels) {
 
       for (var flag of labels) {
         console.log(labels)
-        if ((flag.val === "sexual") || (flag.val === "porn")) {
+        if ((flag.val === "sexual") || (flag.val === "porn") || (flag.val === "nudity")) {
   
           isExplicit = true;
         }

--- a/labels.js
+++ b/labels.js
@@ -260,26 +260,31 @@ export function labelStruct(did, sourceLabels) {
 }
 
 export function isExplicit(labels) {
-
-  if (localStorage.getItem("labels") === null) {
-    
-    return "";
-  }
   
   const flagSaveData = JSON.parse(localStorage.getItem("labels"));
   
-  if (Object.keys(flagSaveData).length === 0) {
-    
-    return "";
-  }
+  var enabledFlags = ["LabeledAccounts"];
   
-  var enabledFlags = [];
-  
-  for (var i = 0; i < Object.keys(flagSaveData).length; i++) {
-    
-    if (flagSaveData[Object.keys(flagSaveData)[i]] === "true") {
+  if (flagSaveData) {
+
+    for (var i = 0; i < Object.keys(flagSaveData).length; i++) {
       
-      enabledFlags.push(Object.keys(flagSaveData)[i]);
+      if (flagSaveData[Object.keys(flagSaveData)[i]] === "true") {
+
+        var insideAlready = false;
+        for (var o = 0; i < enabledFlags.length; o++) {
+
+          if (Object.keys(flagSaveData)[i] === enabledFlags[o]) {
+
+            insideAlready = true;
+          }
+        }
+
+        if (insideAlready === false) {
+
+          enabledFlags.push(Object.keys(flagSaveData)[i]);
+        }
+      }
     }
   }
   

--- a/mods.js
+++ b/mods.js
@@ -37,19 +37,20 @@ export async function embeds(obj) {
         divisor = 2;
       }
 
+      //console.log("Building image objects for embeds: ", obj)
+
       for (var i = 0; i < obj.images.length; i++) {
 
-        if (obj.images[i].image.ref.$link == undefined) {
+        if ((obj.images[i].image.ref.$link == undefined) && (obj.images[i].image.ref.value == undefined)) {
 
-          console.log(obj);
+          console.log("No image in image embed obj!", obj);
           return "";
         }
 
-        obj.images[i].thumb = cdnRoute + "/img/feed_fullsize/plain/" + obj.repoDid + "/" + obj.images[i].image.ref.$link + "@jpeg";
-        obj.images[i].fullsize = cdnRoute + "/img/feed_fullsize/plain/" + obj.repoDid + "/" + obj.images[i].image.ref.$link + "@jpeg";
-        
-        if (obj.images[i].image.ref.$link == undefined) console.log(obj);
-        console.log(obj.images[i].image.ref.$link)
+        const imgCid = (obj.images[i].image.ref.$link != undefined) ? obj.images[i].image.ref.$link : obj.images[i].image.ref.value;
+
+        obj.images[i].thumb = cdnRoute + "/img/feed_fullsize/plain/" + obj.repoDid + "/" + imgCid + "@jpeg";
+        obj.images[i].fullsize = cdnRoute + "/img/feed_fullsize/plain/" + obj.repoDid + "/" + imgCid + "@jpeg";
 
         var row;
         var rowend;

--- a/mods.js
+++ b/mods.js
@@ -1,4 +1,4 @@
-import { getUserRepo, listRecords } from "../../../api.js";
+import { cdnRoute, getUserRepo, listRecords } from "../../../api.js";
 import { postDefault } from "../../../struct/default.js";
 import { postFull } from "../../../struct/full.js";
 
@@ -7,7 +7,7 @@ export async function embeds(obj) {
 
   switch (obj["$type"]) {
     case "app.bsky.embed.images":
-      var amount = obj.images.length;
+      /*var amount = obj.images.length;
 
       if (amount === 1) {
         return (
@@ -28,7 +28,108 @@ export async function embeds(obj) {
         }
 
         return newElement + `Attached: ${amount} images</h3>`;
+      }*/
+
+      var imageEmbed = "<div style='display: grid; gap: 0.5rem; width: inherit;'>";
+
+      var divisor = 1;
+      if (obj.images.length > 1) {
+        divisor = 2;
       }
+
+      for (var i = 0; i < obj.images.length; i++) {
+
+        if (obj.images[i].image.ref.$link == undefined) {
+
+          console.log(obj);
+          return "";
+        }
+
+        obj.images[i].thumb = cdnRoute + "/img/feed_fullsize/plain/" + obj.repoDid + "/" + obj.images[i].image.ref.$link + "@jpeg";
+        obj.images[i].fullsize = cdnRoute + "/img/feed_fullsize/plain/" + obj.repoDid + "/" + obj.images[i].image.ref.$link + "@jpeg";
+        
+        if (obj.images[i].image.ref.$link == undefined) console.log(obj);
+        console.log(obj.images[i].image.ref.$link)
+
+        var row;
+        var rowend;
+        var column;
+        var columnend;
+        var width;
+        
+        if (i === 0) {
+          
+          row = 1;
+          column = 1;
+          
+          if (obj.images.length === 3) {
+             
+            
+            row = 1;
+            rowend = 3;
+            column = 1;
+            columnend = 3;
+          }
+        } else if (i === 1) {
+          row = 1;
+          column = 2;
+          
+          if (obj.images.length === 3) {
+
+            row = 2;
+            rowend = 1;
+            column = 3;
+            columnend = 3;
+          }
+        } else if (i === 2) {
+          row = 2;
+          column = 1;
+          
+          if (obj.images.length === 3) {
+
+            row = 2;
+            rowend = 2;
+            column = 3;
+            columnend = 3;
+          }
+        } else if (i === 3) {
+          row = 2;
+          column = 2;
+        }
+
+        var index;
+        var crops = "object-fit: cover; width: 100%; height: 100%;";
+        if (obj.images.length === 1) {
+          index = "object-fit: contain; grid-column-start: 1; grid-column-end: 2; grid-row-start: 1; grid-row-end: 2;";
+        } else if (obj.images.length === 2) {
+          index = `aspect-ratio: 1/1; object-fit: cover; grid-column-start: ${column}; grid-column-end: ${column}; grid-row-start: 1; grid-row-end: 2;`;
+          crops = "object-fit: cover; width: 100%; height: 100%;";
+        } else if (obj.images.length === 3) {
+          index = `aspect-ratio: 1/1; object-fit: cover; grid-column-start: ${column}; grid-column-end: ${columnend}; grid-row-start: ${row}; grid-row-end: ${rowend};`;
+          crops = "object-fit: cover; width: 100%; height: 100%;";
+        } else if (obj.images.length === 4) {
+          index = `aspect-ratio: 1/1; object-fit: cover; grid-column-start: ${column}; grid-column-end: ${column}; grid-row-start: ${row}; grid-row-end: ${row};`;
+          crops = "object-fit: cover; width: 100%; height: 100%;";
+        } else {
+          return "<div>More than 4 images</div>";
+        }
+
+        var blurs = "";
+        var clickFunc = `window.open('${obj.images[i].fullsize}')`;
+
+        if (obj.explicit === true) {
+
+          blurs = "filter: blur(8px);";
+          clickFunc = `this.style.filter = 'none'; this.onclick = function() { window.open('${obj.images[i].fullsize}'); }`;
+        }
+
+        imageEmbed =
+          imageEmbed +
+          `<div style="overflow: hidden; justify-content: center; border-radius: 7px; ${index}"><img onclick="${clickFunc}" src="${obj.images[i].thumb}" title="${obj.images[i].alt}" style="cursor: pointer; transition: 0.1s cubic-bezier(.3,.09,.46,1.01) 0s; ${crops} ${blurs}"></div>`;
+      }
+
+      return imageEmbed + "</div>";
+      break;
     case "app.bsky.embed.images#view":
       var imageEmbed =
         "<div style='display: grid; gap: 0.5rem; width: inherit;'>";

--- a/struct/default.js
+++ b/struct/default.js
@@ -155,6 +155,8 @@ export async function postDefault(userId, post, type) {
     }
     
     if (postObj.value.embed != undefined) {
+
+      postObj.value.embed.repoDid = userObj.did;
       
       if (postObj.value.text != "") {
         

--- a/struct/default.js
+++ b/struct/default.js
@@ -1,5 +1,5 @@
 import { getPost, getUserRepo, listRecords, getUserInfo } from "../../../../api.js";
-import { labelHandle, labelUsername } from "../../../../labels.js";
+import { labelHandle, labelUsername, isExplicit } from "../../../../labels.js";
 import { embeds } from "../../../../mods.js";
 
 export async function postDefault(userId, post, type) {
@@ -9,6 +9,11 @@ export async function postDefault(userId, post, type) {
   
   var postObj;
   var isObj = false;
+
+  if ((userProfileObj === null) || (userObj === null)) {
+
+    return "";
+  }
   
   if (typeof post === 'object' && post.constructor === Object) {
     
@@ -75,14 +80,26 @@ export async function postDefault(userId, post, type) {
     
     var usernameElement;
     var handleElement;
+
+    var labels = null;
+
+    if (postObj.labels) {
+    
+      if (postObj.labels.values.length != 0) {
+
+        labels = postObj.labels;
+      }
+    }
+
+    const explicit = isExplicit(labels);
     
     if ((userProfileObj === null) || (userProfileObj[0].value.displayName === "") || (userProfileObj[0].value.displayName === undefined)) {
       
       usernameElement = "";
-      handleElement = labelHandle(userId, textSize, userObj.handle);
+      handleElement = labelHandle(userId, textSize, userObj.handle, labels);
     } else {
       
-      usernameElement = labelUsername(userId, textSize, userProfileObj[0].value.displayName);
+      usernameElement = labelUsername(userId, textSize, userProfileObj[0].value.displayName, labels);
       handleElement = `<h3 style="${textSize}">@<a onclick="addLocation(event);" href="${document.location.origin}/user/${userObj.handle}" title="Go to User Profile" class="userRedir">${userObj.handle}</a></h3>`;
     }
     
@@ -155,6 +172,8 @@ export async function postDefault(userId, post, type) {
     }
     
     if (postObj.value.embed != undefined) {
+
+      postObj.value.embed.explicit = explicit;
 
       postObj.value.embed.repoDid = userObj.did;
       


### PR DESCRIPTION
This change allows for viewing of images on the ATP without needing to be logged in. This is possible due to \*semi\*-recent changes to the technology.

Once federation is possible on the ATP, there will most likely be either a CDN pointer in the PDS, possibly in `com.atproto.server.describeServer`, however at this moment the route will be described in `api.js`.